### PR TITLE
Links from emails to these routes not rest

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-
 var path = require('path');
 var uuid = require('node-uuid');
 var ms = require('ms');
@@ -39,9 +38,6 @@ var Signup = module.exports = function(app, config) {
 
   // set up the default route
   var route = cfg.route || '/signup';
-
-  // change URLs if REST is active
-  if (config.rest) route = '/rest' + route;
 
   /**
    * Routes


### PR DESCRIPTION
When building the signup emails, according to my other pull request, the links in the email do not contain '/rest/...' so the routes are never caught here. The nature of these routes mean the users are likely to go directly (via the email link) rather than through the rest client on the front end. 
Admittedly I have yet to try all the outcomes of this module yet so we may need to be a bit cleverer about which routes are prepended with or without '/rest', but the getSignupToken certainly doesn't require rest. All methods check the config.rest again anyway before handling the views.
