### PR TITLE
Pass the original signup form req object to the signup::post event

### DIFF
--- a/index.js
+++ b/index.js
@@ -179,7 +179,7 @@ Signup.prototype.postSignup = function(req, res, next) {
           if (signupErr) {return next(signupErr); }
 
           // emit event
-          that.emit('signup::post', savedUser);
+          that.emit('signup::post', savedUser, req);
 
           // send only JSON when REST is active
           if (config.rest) {return res.send(204); }


### PR DESCRIPTION
Pass the original signup form req object to the signup::post event, so that an event handler can extract any extra information from that form and use it however it chooses (for example, to save any extra data added in that form into another table).
